### PR TITLE
Initialize route planning agent scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for bokkapro-ai-agent
+API_BASE_URL=https://api.example.com
+API_KEY=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# bokkapro-ai-agent
-Autonomous route planning agent for BokkaPro. Retrieves logistics data, generates optimized pickup/delivery schedules, reacts to operational changes, and posts results to the backend. Built with Python and OR-Tools, designed for future AI integration.
+# BokkaPro AI Agent
+
+Autonomous route planning agent for BokkaPro's logistics platform.
+
+## Features
+
+- Retrieves logistics data from backend APIs.
+- Generates optimized routes using OR-Tools.
+- Reacts to real-time events and scheduled tasks.
+- Exposes FastAPI endpoints for manual control.
+- Designed for future AI/ML integration.
+
+## Development
+
+This project is under active development. All modules currently contain placeholder implementations.
+
+### Running the API
+
+```
+uvicorn main:app --reload
+```
+
+### Testing
+
+```
+pytest
+```
+
+## Environment Variables
+
+See `.env.example` for required settings.

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the autonomous route planning agent."""

--- a/agent/data_fetcher.py
+++ b/agent/data_fetcher.py
@@ -1,0 +1,14 @@
+"""Retrieves data from backend endpoints."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DataFetcher:
+    """Placeholder data fetcher."""
+
+    def fetch_all(self):
+        """Fetch vehicles, crews, pickups, deliveries, and offices."""
+        # TODO: Implement data retrieval
+        pass

--- a/agent/models.py
+++ b/agent/models.py
@@ -1,0 +1,17 @@
+"""Dataclasses for vehicles, tasks, and related entities."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Vehicle:
+    """Represents a delivery vehicle."""
+    id: int
+    status: str
+
+
+@dataclass
+class Task:
+    """Represents a delivery or pickup task."""
+    id: int
+    type: str

--- a/agent/planner.py
+++ b/agent/planner.py
@@ -1,0 +1,14 @@
+"""Route planning logic using OR-Tools."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Planner:
+    """Placeholder planner using OR-Tools."""
+
+    def plan(self):
+        """Perform planning and return schedule."""
+        # TODO: Implement planning algorithm
+        pass

--- a/agent/reporter.py
+++ b/agent/reporter.py
@@ -1,0 +1,14 @@
+"""Sends the generated schedule to backend."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Reporter:
+    """Placeholder reporter."""
+
+    def report(self, schedule) -> None:
+        """Send schedule to backend."""
+        # TODO: Implement reporting logic
+        pass

--- a/agent/route_agent.py
+++ b/agent/route_agent.py
@@ -1,0 +1,14 @@
+"""Main agent class orchestrating the lifecycle."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class RouteAgent:
+    """Placeholder route agent."""
+
+    def run(self) -> None:
+        """Trigger the planning workflow."""
+        # TODO: Implement agent run logic
+        pass

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -1,0 +1,14 @@
+"""Handles scheduled and event-based execution."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Scheduler:
+    """Placeholder scheduler for cron and real-time triggers."""
+
+    def start(self) -> None:
+        """Start scheduler."""
+        # TODO: Implement scheduling logic
+        pass

--- a/api/api.py
+++ b/api/api.py
@@ -1,0 +1,19 @@
+"""FastAPI endpoints to manually trigger planning and check status."""
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.post("/agent/run")
+def run_agent() -> dict:
+    """Trigger manual re-planning."""
+    # TODO: Integrate with RouteAgent
+    return {"status": "scheduled"}
+
+
+@app.get("/agent/status")
+def agent_status() -> dict:
+    """Return current agent status."""
+    # TODO: Return real status
+    return {"status": "idle"}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+"""Loads environment configuration and defines global constants."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Placeholder configuration values
+API_BASE_URL = "https://api.example.com"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,21 @@
+"""Launches FastAPI server and initializes the route planning agent."""
+
+import logging
+
+from api.api import app
+
+logger = logging.getLogger(__name__)
+
+
+def init_agent() -> None:
+    """Initialize agent components on startup."""
+    # TODO: Set up RouteAgent and Scheduler
+    pass
+
+
+if __name__ == "__main__":
+    # Placeholder server startup
+    import uvicorn
+
+    init_agent()
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110.0,<0.111.0
+uvicorn>=0.29.0,<0.30.0
+ortools>=9.9.0
+python-dotenv>=1.0.0

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,14 @@
+"""Test cases for the Planner placeholder."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from agent.planner import Planner
+
+
+def test_planner_instance() -> None:
+    """Planner can be instantiated."""
+    planner = Planner()
+    assert planner is not None


### PR DESCRIPTION
## Summary
- set up placeholder modules for route planning agent
- add FastAPI endpoints and configuration stubs
- include sample test and development dependencies

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a14797cf40832d8ac4bf34d3a1b10f