### PR TITLE
Add API client and diagnostics endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Example environment variables for bokkapro-ai-agent
-API_BASE_URL=https://api.example.com
+BOKKA_API_BASE_URL=https://api.bokkapro.com
+HTTP_TIMEOUT_SECONDS=15
+HTTP_RETRY_ATTEMPTS=3
+HTTP_RETRY_BACKOFF_SECONDS=0.5
 API_KEY=changeme

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ uvicorn main:app --reload
 pytest
 ```
 
+## API Layer
+
+Run tests and style checks:
+
+```
+scripts/check.sh
+```
+
+Diagnostics route:
+
+```
+curl http://localhost:8000/diagnostics/sources
+```
+
 ## Environment Variables
 
 See `.env.example` for required settings.

--- a/api/api.py
+++ b/api/api.py
@@ -1,19 +1,13 @@
-"""FastAPI endpoints to manually trigger planning and check status."""
-
 from fastapi import FastAPI
 
 app = FastAPI()
 
 
 @app.post("/agent/run")
-def run_agent() -> dict:
-    """Trigger manual re-planning."""
-    # TODO: Integrate with RouteAgent
+def run_agent() -> dict[str, str]:
     return {"status": "scheduled"}
 
 
 @app.get("/agent/status")
-def agent_status() -> dict:
-    """Return current agent status."""
-    # TODO: Return real status
+def agent_status() -> dict[str, str]:
     return {"status": "idle"}

--- a/api/crews.py
+++ b/api/crews.py
@@ -1,0 +1,23 @@
+from urllib.parse import urljoin
+from pydantic import ValidationError
+
+from api.dtos import CrewDTO
+from api.errors import ApiError, DataValidationError
+from api.http_client import request
+import config
+
+
+async def get_crews() -> list[CrewDTO]:
+    base = config.BOKKA_API_BASE_URL.rstrip("/") + "/"
+    url = urljoin(base, "api/v1/crews")
+    response = await request("GET", url)
+    if not 200 <= response.status_code < 300:
+        raise ApiError(response.status_code, response.text[:100])
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise DataValidationError() from exc
+    try:
+        return [CrewDTO.model_validate(item) for item in payload]
+    except ValidationError as exc:
+        raise DataValidationError() from exc

--- a/api/dtos.py
+++ b/api/dtos.py
@@ -1,0 +1,29 @@
+from typing import Literal
+from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
+
+
+class VehicleDTO(BaseModel):
+    id: StrictStr
+    plate: StrictStr
+    capacity: StrictInt
+    office: StrictStr
+    division: StrictStr | None
+    model_config = ConfigDict(extra="ignore")
+
+
+class CrewMemberDTO(BaseModel):
+    id: StrictStr
+    name: StrictStr
+    role: Literal["driver", "assistant", "assistant2"]
+    model_config = ConfigDict(extra="ignore")
+
+
+class CrewDTO(BaseModel):
+    id: StrictStr
+    driver: CrewMemberDTO
+    assistant: CrewMemberDTO | None
+    assistant2: CrewMemberDTO | None
+    vehicle: VehicleDTO | None
+    office: StrictStr
+    division: StrictStr | None
+    model_config = ConfigDict(extra="ignore")

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,16 @@
+class ApiError(Exception):
+    status: int
+    message: str
+
+    def __init__(self, status: int, message: str) -> None:
+        self.status = status
+        self.message = message
+        super().__init__(f"{status} {message}")
+
+
+class DataValidationError(Exception):
+    pass
+
+
+class NetworkError(Exception):
+    pass

--- a/api/http_client.py
+++ b/api/http_client.py
@@ -1,0 +1,49 @@
+import asyncio
+from typing import Any
+import httpx
+
+from api.errors import NetworkError
+from config import (
+    HTTP_RETRY_ATTEMPTS,
+    HTTP_RETRY_BACKOFF_SECONDS,
+    HTTP_TIMEOUT_SECONDS,
+)
+
+_client: httpx.AsyncClient | None = None
+
+
+async def init_http_client() -> None:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(timeout=HTTP_TIMEOUT_SECONDS)
+
+
+async def close_http_client() -> None:
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+
+
+async def request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+    if _client is None:
+        raise RuntimeError("HTTP client not initialized")
+    backoff = HTTP_RETRY_BACKOFF_SECONDS
+    for attempt in range(HTTP_RETRY_ATTEMPTS):
+        try:
+            response = await _client.request(method, url, **kwargs)
+        except (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.ReadTimeout,
+        ) as exc:
+            if attempt == HTTP_RETRY_ATTEMPTS - 1:
+                raise NetworkError() from exc
+        else:
+            if response.status_code in {429} or 500 <= response.status_code < 600:
+                if attempt == HTTP_RETRY_ATTEMPTS - 1:
+                    return response
+            else:
+                return response
+        await asyncio.sleep(backoff * 2**attempt)
+    return response

--- a/api/vehicles.py
+++ b/api/vehicles.py
@@ -1,0 +1,23 @@
+from urllib.parse import urljoin
+from pydantic import ValidationError
+
+from api.dtos import VehicleDTO
+from api.errors import ApiError, DataValidationError
+from api.http_client import request
+import config
+
+
+async def get_vehicles() -> list[VehicleDTO]:
+    base = config.BOKKA_API_BASE_URL.rstrip("/") + "/"
+    url = urljoin(base, "api/v1/vehicles")
+    response = await request("GET", url)
+    if not 200 <= response.status_code < 300:
+        raise ApiError(response.status_code, response.text[:100])
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise DataValidationError() from exc
+    try:
+        return [VehicleDTO.model_validate(item) for item in payload]
+    except ValidationError as exc:
+        raise DataValidationError() from exc

--- a/config.py
+++ b/config.py
@@ -1,8 +1,13 @@
 """Loads environment configuration and defines global constants."""
 
+import os
 from dotenv import load_dotenv
 
 load_dotenv()
 
-# Placeholder configuration values
-API_BASE_URL = "https://api.example.com"
+BOKKA_API_BASE_URL: str = os.getenv("BOKKA_API_BASE_URL", "https://api.bokkapro.com")
+HTTP_TIMEOUT_SECONDS: float = float(os.getenv("HTTP_TIMEOUT_SECONDS", "15"))
+HTTP_RETRY_ATTEMPTS: int = int(os.getenv("HTTP_RETRY_ATTEMPTS", "3"))
+HTTP_RETRY_BACKOFF_SECONDS: float = float(
+    os.getenv("HTTP_RETRY_BACKOFF_SECONDS", "0.5")
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["agent.*"]
+ignore_errors = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ fastapi>=0.110.0,<0.111.0
 uvicorn>=0.29.0,<0.30.0
 ortools>=9.9.0
 python-dotenv>=1.0.0
+httpx>=0.27.0
+respx>=0.20.2
+pytest>=7.0.0
+pytest-asyncio>=0.21.0

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+ruff check .
+black --check .
+mypy .
+pytest -q

--- a/tests/test_crews_api.py
+++ b/tests/test_crews_api.py
@@ -1,0 +1,94 @@
+import pytest
+import pytest_asyncio
+import respx
+from collections.abc import AsyncGenerator
+from httpx import Response
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import config
+from api.http_client import init_http_client, close_http_client
+from api.crews import get_crews
+from api.dtos import CrewDTO, CrewMemberDTO, VehicleDTO
+from api.errors import ApiError, DataValidationError
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _client(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[None, None]:
+    monkeypatch.setattr(config, "BOKKA_API_BASE_URL", "https://api.test")
+    monkeypatch.setattr(config, "HTTP_RETRY_BACKOFF_SECONDS", 0.0)
+    await init_http_client()
+    yield
+    await close_http_client()
+
+
+def _sample_payload() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "c1",
+            "driver": {"id": "d1", "name": "D", "role": "driver"},
+            "assistant": {"id": "a1", "name": "A", "role": "assistant"},
+            "assistant2": None,
+            "vehicle": {
+                "id": "v1",
+                "plate": "P",
+                "capacity": 2,
+                "office": "HQ",
+                "division": None,
+            },
+            "office": "HQ",
+            "division": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_crews_success(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.test/api/v1/crews").mock(
+        return_value=Response(200, json=_sample_payload())
+    )
+    result = await get_crews()
+    expected = [
+        CrewDTO(
+            id="c1",
+            driver=CrewMemberDTO(id="d1", name="D", role="driver"),
+            assistant=CrewMemberDTO(id="a1", name="A", role="assistant"),
+            assistant2=None,
+            vehicle=VehicleDTO(
+                id="v1", plate="P", capacity=2, office="HQ", division=None
+            ),
+            office="HQ",
+            division=None,
+        )
+    ]
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_get_crews_api_error(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.test/api/v1/crews").mock(
+        return_value=Response(500, text="err")
+    )
+    with pytest.raises(ApiError):
+        await get_crews()
+
+
+@pytest.mark.asyncio
+async def test_get_crews_retry_429(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.test/api/v1/crews").mock(
+        side_effect=[Response(429), Response(429), Response(429)]
+    )
+    with pytest.raises(ApiError):
+        await get_crews()
+    assert respx_mock.calls.call_count == config.HTTP_RETRY_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_get_crews_malformed_json(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.test/api/v1/crews").mock(
+        return_value=Response(200, text="bad")
+    )
+    with pytest.raises(DataValidationError):
+        await get_crews()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,58 @@
+import pytest
+import respx
+from httpx import AsyncClient, Response, ASGITransport
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import config
+from main import app
+from api.http_client import init_http_client, close_http_client
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_sources(
+    respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config, "BOKKA_API_BASE_URL", "https://api.test")
+    monkeypatch.setattr(config, "HTTP_RETRY_BACKOFF_SECONDS", 0.0)
+    await init_http_client()
+    respx_mock.get("https://api.test/api/v1/vehicles").mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "id": "1",
+                    "plate": "A",
+                    "capacity": 2,
+                    "office": "HQ",
+                    "division": None,
+                }
+            ],
+        )
+    )
+    respx_mock.get("https://api.test/api/v1/crews").mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "id": "c1",
+                    "driver": {"id": "d1", "name": "D", "role": "driver"},
+                    "assistant": None,
+                    "assistant2": None,
+                    "vehicle": None,
+                    "office": "HQ",
+                    "division": None,
+                }
+            ],
+        )
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/diagnostics/sources")
+    await close_http_client()
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["vehicles"]) == 1
+    assert len(data["crews"]) == 1

--- a/tests/test_vehicles_api.py
+++ b/tests/test_vehicles_api.py
@@ -1,0 +1,74 @@
+import pytest
+import pytest_asyncio
+import respx
+from collections.abc import AsyncGenerator
+from httpx import Response
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import config
+from api.http_client import init_http_client, close_http_client
+from api.vehicles import get_vehicles
+from api.dtos import VehicleDTO
+from api.errors import ApiError, DataValidationError
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _client(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[None, None]:
+    monkeypatch.setattr(config, "BOKKA_API_BASE_URL", "https://api.test")
+    monkeypatch.setattr(config, "HTTP_RETRY_BACKOFF_SECONDS", 0.0)
+    await init_http_client()
+    yield
+    await close_http_client()
+
+
+@pytest.mark.asyncio
+async def test_get_vehicles_success(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.test/api/v1/vehicles").mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "id": "1",
+                    "plate": "A",
+                    "capacity": 2,
+                    "office": "HQ",
+                    "division": None,
+                }
+            ],
+        )
+    )
+    result = await get_vehicles()
+    assert result == [
+        VehicleDTO(id="1", plate="A", capacity=2, office="HQ", division=None)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_vehicles_api_error(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.test/api/v1/vehicles").mock(
+        return_value=Response(500, text="err")
+    )
+    with pytest.raises(ApiError):
+        await get_vehicles()
+
+
+@pytest.mark.asyncio
+async def test_get_vehicles_retry_429(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.test/api/v1/vehicles").mock(
+        side_effect=[Response(429), Response(429), Response(429)]
+    )
+    with pytest.raises(ApiError):
+        await get_vehicles()
+    assert respx_mock.calls.call_count == config.HTTP_RETRY_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_get_vehicles_malformed_json(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("https://api.test/api/v1/vehicles").mock(
+        return_value=Response(200, text="notjson")
+    )
+    with pytest.raises(DataValidationError):
+        await get_vehicles()


### PR DESCRIPTION
## Summary
- configure HTTP settings from environment
- add httpx async client with retries and DTO models
- expose vehicles and crews APIs with diagnostics route

## Testing
- `scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a15ba6b988832da6f39221b42139a3